### PR TITLE
mido: sepolicy: Define qti_debugfs

### DIFF
--- a/sepolicy/vendor/file.te
+++ b/sepolicy/vendor/file.te
@@ -1,6 +1,9 @@
 # Camera
 type camera_socket, file_type, data_file_type;
 
+# DebugFS
+type qti_debugfs, fs_type, debugfs_type;
+
 # Fingerprint
 type fpc_data_file, file_type, data_file_type, core_data_file_type;
 type fpce_socket, file_type;


### PR DESCRIPTION
* Fixes Error: exited with code: 1
Command: out/host/linux-x86/bin/checkpolicy -C -M -c 30 -o out/soong/.intermediates/system/sepolicy/recovery_sepolicy.cil/android_common/recovery_sepolicy.cil out/soong/.intermediates/system/sepolicy/recovery_sepolicy.conf/android_common/recovery_sepolicy.conf # hash of input list: a316674d1dc0868a105f79e687a4b6449e6a8801cfa3253b9c426787c1c40d09 Output:
device/xiaomi/mido/sepolicy/vendor/ueventd.te:5:ERROR 'unknown type qti_debugfs' at token ';' on line 127056: allow ueventd qti_debugfs:dir relabelto;